### PR TITLE
[BUGFIX] Do not enable bleeding edge by default

### DIFF
--- a/phpstan-base.neon.dist
+++ b/phpstan-base.neon.dist
@@ -1,6 +1,3 @@
-includes:
-	- %rootDir%/conf/bleedingEdge.neon
-
 parameters:
 	# Open files in PhpStorm
 	editorUrl: 'phpstorm://open?file=%%file%%&line=%%line%%'


### PR DESCRIPTION
Bleeding edge causes failures with Rector if this package is required along with PHPStan's extension installer (see rectorphp/rector#2431). Thus, it's disabled for now until a better solution is found. Until then, it must be actively enabled in projects.