### PR TITLE
[BUGFIX] Configure analyzed paths as absolute paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ to your `phpstan.php` file:
 
 use EliasHaeussler\PHPStanConfig;
 
-$config = PHPStanConfig\Config\Config::create()->in(
+$config = PHPStanConfig\Config\Config::create(__DIR__)->in(
     'src',
     'tests',
 );

--- a/phpstan.php
+++ b/phpstan.php
@@ -23,7 +23,7 @@ declare(strict_types=1);
 
 use EliasHaeussler\PHPStanConfig\Config;
 
-return Config\Config::create()
+return Config\Config::create(__DIR__)
     ->in('src', 'tests/src')
     ->withBleedingEdge()
     ->maxLevel()

--- a/tests/src/Config/ConfigTest.php
+++ b/tests/src/Config/ConfigTest.php
@@ -39,7 +39,7 @@ final class ConfigTest extends Framework\TestCase
 
     protected function setUp(): void
     {
-        $this->subject = Src\Config\Config::create();
+        $this->subject = Src\Config\Config::create('/my-project/');
     }
 
     #[Framework\Attributes\Test]
@@ -66,14 +66,15 @@ final class ConfigTest extends Framework\TestCase
     #[Framework\Attributes\Test]
     public function inConfiguresPaths(): void
     {
-        $this->subject->in('foo', 'baz');
+        $this->subject->in('foo', 'baz', '/foo/baz');
 
         $expected = [
             'includes' => [],
             'parameters' => [
                 'paths' => [
-                    'foo',
-                    'baz',
+                    '/my-project/foo',
+                    '/my-project/baz',
+                    '/foo/baz',
                 ],
             ],
         ];
@@ -90,8 +91,8 @@ final class ConfigTest extends Framework\TestCase
             'includes' => [],
             'parameters' => [
                 'excludePaths' => [
-                    'foo',
-                    'baz',
+                    '/my-project/foo',
+                    '/my-project/baz',
                 ],
             ],
         ];


### PR DESCRIPTION
This PR fixes a bug with analyzed paths when using the PHP API for PHPStan configuration. Due to a limitation within PHPStan, relative paths may not properly resolved, see https://github.com/phpstan/phpstan/issues/9366#issuecomment-1566223082.

To fix this issue, it's now required to provide the project directory within `Config::create()`. As an alternative, paths passed to `Config::in()` and `Config::not()` may be absolute. In this case, the project directory is not prepended.