### PR TITLE
[FEATURE] Allow configuration of bleeding edge feature toggles

### DIFF
--- a/src/Config/Config.php
+++ b/src/Config/Config.php
@@ -125,10 +125,16 @@ final class Config
     }
 
     /**
+     * @param array<non-empty-string, bool> $featureToggles
+     *
      * @see https://phpstan.org/blog/what-is-bleeding-edge
      */
-    public function withBleedingEdge(): self
+    public function withBleedingEdge(array $featureToggles = []): self
     {
+        foreach ($featureToggles as $name => $value) {
+            $this->parameters->set('featureToggles/'.$name, $value);
+        }
+
         return $this->with('phar://phpstan.phar/conf/bleedingEdge.neon');
     }
 

--- a/tests/src/Config/ConfigTest.php
+++ b/tests/src/Config/ConfigTest.php
@@ -146,6 +146,29 @@ final class ConfigTest extends Framework\TestCase
     }
 
     #[Framework\Attributes\Test]
+    public function withBleedingEdgeTogglesGivenFeatures(): void
+    {
+        $this->subject->withBleedingEdge([
+            'consistentConstructor' => false,
+            'explicitMixedForGlobalVariables' => false,
+        ]);
+
+        $expected = [
+            'includes' => [
+                'phar://phpstan.phar/conf/bleedingEdge.neon',
+            ],
+            'parameters' => [
+                'featureToggles' => [
+                    'consistentConstructor' => false,
+                    'explicitMixedForGlobalVariables' => false,
+                ],
+            ],
+        ];
+
+        self::assertSame($expected, $this->subject->toArray());
+    }
+
+    #[Framework\Attributes\Test]
     public function withBaselineConfiguresIncludeForBaselineFile(): void
     {
         $this->subject->withBaseline();


### PR DESCRIPTION
This PR extends the `Config::withBleedingEdge()` method to allow configuration of bleeding edge feature toggles.