### PR TITLE
[BUGFIX] Use explicit parameter for excludePaths

### DIFF
--- a/src/Config/Config.php
+++ b/src/Config/Config.php
@@ -97,7 +97,7 @@ final class Config
     {
         $paths = array_map($this->expandPath(...), $paths);
 
-        $this->parameters->add('excludePaths', ...$paths);
+        $this->parameters->add('excludePaths/analyseAndScan', ...$paths);
 
         return $this;
     }

--- a/tests/src/Config/ConfigTest.php
+++ b/tests/src/Config/ConfigTest.php
@@ -91,8 +91,10 @@ final class ConfigTest extends Framework\TestCase
             'includes' => [],
             'parameters' => [
                 'excludePaths' => [
-                    '/my-project/foo',
-                    '/my-project/baz',
+                    'analyseAndScan' => [
+                        '/my-project/foo',
+                        '/my-project/baz',
+                    ],
                 ],
             ],
         ];


### PR DESCRIPTION
The `excludePaths` config seems not to be supported with the PHP configuration file. Thus, we're using the more explicit `excludePaths/analyseAndScan` config.