### PR TITLE
[FEATURE] Allow configuration of `treatPhpDocTypesAsCertain` parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,9 @@ $config->reportUnmatchedIgnoredErrors(false);
 // Define error formatter
 $config->formatAs(PHPStanConfig\Enums\ErrorFormat::Json);
 
+// Treat phpdoc types as certain
+$config->treatPhpDocTypesAsCertain();
+
 // Include Doctrine set
 $doctrineSet = PHPStanConfig\Set\DoctrineSet::create()
     ->withObjectManagerLoader('tests/object-manager.php')

--- a/src/Config/Config.php
+++ b/src/Config/Config.php
@@ -255,6 +255,16 @@ final class Config
     }
 
     /**
+     * @see https://phpstan.org/config-reference#treatphpdoctypesascertain
+     */
+    public function treatPhpDocTypesAsCertain(bool $enable = true): self
+    {
+        $this->parameters->set('treatPhpDocTypesAsCertain', $enable);
+
+        return $this;
+    }
+
+    /**
      * @return array{
      *     includes: list<non-empty-string>,
      *     parameters: array<non-empty-string, mixed>,

--- a/tests/src/Config/ConfigTest.php
+++ b/tests/src/Config/ConfigTest.php
@@ -350,6 +350,21 @@ final class ConfigTest extends Framework\TestCase
         self::assertSame($expected, $this->subject->toArray());
     }
 
+    #[Framework\Attributes\Test]
+    public function treatPhpDocTypesAsCertainConfiguresTreatPhpDocTypesAsCertain(): void
+    {
+        $this->subject->treatPhpDocTypesAsCertain();
+
+        $expected = [
+            'includes' => [],
+            'parameters' => [
+                'treatPhpDocTypesAsCertain' => true,
+            ],
+        ];
+
+        self::assertSame($expected, $this->subject->toArray());
+    }
+
     /**
      * @return Generator<string, array{
      *     non-empty-string|null,


### PR DESCRIPTION
This PR allows to configure the `treatPhpDocTypesAsCertain` parameter.