### PR TITLE
[FEATURE] Publish parameter collection in Config object

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,9 @@ $typo3Set = PHPStanConfig\Set\TYPO3Set::create()
     ->withCustomSiteAttribute('myArrayAttribute', 'array');
 $config->withSets($typo3Set);
 
+// Set custom parameters
+$config->parameters->set('tipsOfTheDay', false);
+
 return $config->toArray();
 ```
 

--- a/src/Config/Config.php
+++ b/src/Config/Config.php
@@ -48,7 +48,7 @@ final class Config
      */
     private function __construct(
         private readonly string $projectDirectory,
-        private readonly Resource\Collection $parameters,
+        public readonly Resource\Collection $parameters,
         private array $includes = [],
         private array $sets = [],
     ) {}


### PR DESCRIPTION
This PR publishes the `$parameters` parameter in the main `Config` object. This allows to set custom PHPStan parameters.