### PR TITLE
[TASK] Explicitly set PHP version constraint for Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,8 @@
 	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
 	"extends": [
 		"local>eliashaeussler/renovate-config"
-	]
+	],
+	"constraints": {
+		"php": "8.1.*"
+	}
 }


### PR DESCRIPTION
This PR explicitly configures the `php` version constraint in `renovate.json`. This is required to avoid package updates without support for PHP 8.1, since Renovate by default does not select the lowest compatible PHP version, see renovatebot/renovate#13637.