### PR TITLE
[FEATURE] Make several exception handling parameters configurable

### DIFF
--- a/src/Config/Config.php
+++ b/src/Config/Config.php
@@ -265,6 +265,16 @@ final class Config
     }
 
     /**
+     * @see https://phpstan.org/config-reference#exceptions
+     */
+    public function checkTooWideThrowTypes(bool $enable = true): self
+    {
+        $this->parameters->set('exceptions/check/tooWideThrowType', $enable);
+
+        return $this;
+    }
+
+    /**
      * @return array{
      *     includes: list<non-empty-string>,
      *     parameters: array<non-empty-string, mixed>,

--- a/src/Config/Config.php
+++ b/src/Config/Config.php
@@ -275,6 +275,16 @@ final class Config
     }
 
     /**
+     * @see https://phpstan.org/config-reference#exceptions
+     */
+    public function reportUncheckedExceptionDeadCatch(bool $enable = true): self
+    {
+        $this->parameters->set('exceptions/reportUncheckedExceptionDeadCatch', $enable);
+
+        return $this;
+    }
+
+    /**
      * @return array{
      *     includes: list<non-empty-string>,
      *     parameters: array<non-empty-string, mixed>,

--- a/tests/src/Config/ConfigTest.php
+++ b/tests/src/Config/ConfigTest.php
@@ -384,6 +384,23 @@ final class ConfigTest extends Framework\TestCase
         self::assertSame($expected, $this->subject->toArray());
     }
 
+    #[Framework\Attributes\Test]
+    public function reportUncheckedExceptionDeadCatchConfiguresReportForUncheckedExceptionDeadCatch(): void
+    {
+        $this->subject->reportUncheckedExceptionDeadCatch();
+
+        $expected = [
+            'includes' => [],
+            'parameters' => [
+                'exceptions' => [
+                    'reportUncheckedExceptionDeadCatch' => true,
+                ],
+            ],
+        ];
+
+        self::assertSame($expected, $this->subject->toArray());
+    }
+
     /**
      * @return Generator<string, array{
      *     non-empty-string|null,

--- a/tests/src/Config/ConfigTest.php
+++ b/tests/src/Config/ConfigTest.php
@@ -365,6 +365,25 @@ final class ConfigTest extends Framework\TestCase
         self::assertSame($expected, $this->subject->toArray());
     }
 
+    #[Framework\Attributes\Test]
+    public function checkTooWideThrowTypesConfiguresExceptionsCheckForTooWideThrowTypes(): void
+    {
+        $this->subject->checkTooWideThrowTypes();
+
+        $expected = [
+            'includes' => [],
+            'parameters' => [
+                'exceptions' => [
+                    'check' => [
+                        'tooWideThrowType' => true,
+                    ],
+                ],
+            ],
+        ];
+
+        self::assertSame($expected, $this->subject->toArray());
+    }
+
     /**
      * @return Generator<string, array{
      *     non-empty-string|null,


### PR DESCRIPTION
This PR adds the `tooWideThrowType` and `reportUncheckedExceptionDeadCatch` parameters to `Config` class.