### PR TITLE
[FEATURE] Introduce `IgnoreAnnotationWithoutErrorIdentifierRule`

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -7,7 +7,7 @@
 /.php-cs-fixer.php        export-ignore
 /CODEOWNERS               export-ignore
 /composer.lock            export-ignore
-/composer-unused.php      export-ignore
+/dependency-checker.json  export-ignore
 /phpstan.php              export-ignore
 /phpunit.xml              export-ignore
 /rector.php               export-ignore

--- a/.github/workflows/cgl.yaml
+++ b/.github/workflows/cgl.yaml
@@ -31,11 +31,15 @@ jobs:
 
       # Install dependencies
       - name: Install Composer dependencies
-        uses: ramsey/composer-install@v3
+        run: composer require --no-progress nikic/php-parser:"*" phpstan/phpdoc-parser:"*"
 
       # Check Composer dependencies
       - name: Check dependencies
-        run: composer-require-checker check
+        run: composer-require-checker check --config-file dependency-checker.json
+      - name: Reset composer.json
+        run: git checkout composer.json composer.lock
+      - name: Re-install Composer dependencies
+        uses: ramsey/composer-install@v3
       - name: Check for unused dependencies
         run: composer-unused
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ composer require eliashaeussler/phpstan-config
 ### With extension installer
 
 If you have the [`phpstan/extension-installer`](https://github.com/phpstan/extension-installer)
-package installed, there's nothing more to do. The [base configuration](phpstan-base.neon.dist)
+package installed, there's nothing more to do. The [base configuration](extension.neon)
 is automatically included.
 
 ### Manual include
@@ -130,6 +130,44 @@ $config->withSets($typo3Set);
 
 // Set custom parameters
 $config->parameters->set('tipsOfTheDay', false);
+
+return $config->toArray();
+```
+
+## 🔎 Rules
+
+The packages also provides some additional PHPStan rules. All rules are enabled by default.
+
+### [`IgnoreAnnotationWithoutErrorIdentifierRule`](src/Rule/IgnoreAnnotationWithoutErrorIdentifierRule.php)
+
+A custom rule to report too loose ignore annotations that don't specify an error identifier.
+By default, both `@phpstan-ignore-line` and `@phpstan-ignore-next-line` annotations are monitored.
+
+```neon
+parameters:
+    ignoreAnnotationWithoutErrorIdentifier:
+        # Enable or disable this rule
+        enabled: true
+        # Define monitored annotations (without "@" prefix)
+        monitoredAnnotations:
+            - phpstan-ignore-line
+            - phpstan-ignore-next-line
+```
+
+This rule can also be customized using the PHP API:
+
+```php
+# phpstan.php
+
+use EliasHaeussler\PHPStanConfig;
+
+$config = PHPStanConfig\Config\Config::create(__DIR__);
+$config->parameters->set('ignoreAnnotationWithoutErrorIdentifier/enabled', false);
+$config->parameters->set('ignoreAnnotationWithoutErrorIdentifier/monitoredAnnotations', [
+    // These annotations don't actually exist, this is just for demonstration purposes
+    'phpstan-ignore-start',
+    'phpstan-ignore-end',
+]);
 
 return $config->toArray();
 ```

--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,8 @@
 		"eliashaeussler/php-cs-fixer-config": "^2.0",
 		"eliashaeussler/rector-config": "^3.0",
 		"ergebnis/composer-normalize": "^2.29",
+		"nikic/php-parser": "*",
+		"phpstan/phpdoc-parser": "*",
 		"phpunit/phpunit": "^10.1 || ^11.0"
 	},
 	"autoload": {
@@ -43,7 +45,7 @@
 	"extra": {
 		"phpstan": {
 			"includes": [
-				"phpstan-base.neon.dist"
+				"extension.neon"
 			]
 		}
 	},

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e08caa17a3bed0028fbcbc041f0aeca2",
+    "content-hash": "02e4dad66843378ad68d47d2dedef7f0",
     "packages": [
         {
             "name": "phpstan/phpstan",
@@ -1881,6 +1881,53 @@
                 "source": "https://github.com/phar-io/version/tree/3.2.1"
             },
             "time": "2022-02-21T01:04:05+00:00"
+        },
+        {
+            "name": "phpstan/phpdoc-parser",
+            "version": "2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpdoc-parser.git",
+                "reference": "c00d78fb6b29658347f9d37ebe104bffadf36299"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/c00d78fb6b29658347f9d37ebe104bffadf36299",
+                "reference": "c00d78fb6b29658347f9d37ebe104bffadf36299",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4 || ^8.0"
+            },
+            "require-dev": {
+                "doctrine/annotations": "^2.0",
+                "nikic/php-parser": "^5.3.0",
+                "php-parallel-lint/php-parallel-lint": "^1.2",
+                "phpstan/extension-installer": "^1.0",
+                "phpstan/phpstan": "^2.0",
+                "phpstan/phpstan-phpunit": "^2.0",
+                "phpstan/phpstan-strict-rules": "^2.0",
+                "phpunit/phpunit": "^9.6",
+                "symfony/process": "^5.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "PHPStan\\PhpDocParser\\": [
+                        "src/"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPDoc parser with support for nullable, intersection and generic types",
+            "support": {
+                "issues": "https://github.com/phpstan/phpdoc-parser/issues",
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/2.0.0"
+            },
+            "time": "2024-10-13T11:29:49+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",

--- a/dependency-checker.json
+++ b/dependency-checker.json
@@ -1,0 +1,9 @@
+{
+	"symbol-whitelist": [
+		"PHPStan\\Analyser\\Scope",
+		"PHPStan\\Rules\\Rule",
+		"PHPStan\\Rules\\RuleError",
+		"PHPStan\\Rules\\RuleErrorBuilder",
+		"PHPStan\\Type\\FileTypeMapper"
+	]
+}

--- a/extension.neon
+++ b/extension.neon
@@ -1,0 +1,27 @@
+parameters:
+	# Open files in PhpStorm
+	editorUrl: 'phpstorm://open?file=%%file%%&line=%%line%%'
+	editorUrlTitle: '%%relFile%%:%%line%%'
+
+	# Rules
+	ignoreAnnotationWithoutErrorIdentifier:
+		enabled: true
+		monitoredAnnotations:
+			- phpstan-ignore-line
+			- phpstan-ignore-next-line
+
+parametersSchema:
+	ignoreAnnotationWithoutErrorIdentifier: structure([
+		enabled: bool()
+		monitoredAnnotations: arrayOf(string())
+	])
+
+conditionalTags:
+	EliasHaeussler\PHPStanConfig\Rule\IgnoreAnnotationWithoutErrorIdentifierRule:
+		phpstan.rules.rule: %ignoreAnnotationWithoutErrorIdentifier.enabled%
+
+services:
+	-
+		class: EliasHaeussler\PHPStanConfig\Rule\IgnoreAnnotationWithoutErrorIdentifierRule
+		arguments:
+			monitoredAnnotations: %ignoreAnnotationWithoutErrorIdentifier.monitoredAnnotations%

--- a/phpstan-base.neon.dist
+++ b/phpstan-base.neon.dist
@@ -1,4 +1,0 @@
-parameters:
-	# Open files in PhpStorm
-	editorUrl: 'phpstorm://open?file=%%file%%&line=%%line%%'
-	editorUrlTitle: '%%relFile%%:%%line%%'

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,4 +1,4 @@
 includes:
-	- phpstan-base.neon.dist
+	- extension.neon
 	- %rootDir%/../../phpstan/phpstan-deprecation-rules/rules.neon
 	- %rootDir%/../../phpstan/phpstan-strict-rules/rules.neon

--- a/src/Rule/IgnoreAnnotationWithoutErrorIdentifierRule.php
+++ b/src/Rule/IgnoreAnnotationWithoutErrorIdentifierRule.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/phpstan-config".
+ *
+ * Copyright (C) 2023-2025 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\PHPStanConfig\Rule;
+
+use PhpParser\Node;
+use PHPStan\Analyser;
+use PHPStan\PhpDocParser;
+use PHPStan\Rules;
+use PHPStan\Type;
+
+use function in_array;
+use function preg_match;
+use function sprintf;
+
+/**
+ * IgnoreAnnotationWithoutErrorIdentifierRule.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ *
+ * @implements Rules\Rule<Node\Stmt>
+ */
+final class IgnoreAnnotationWithoutErrorIdentifierRule implements Rules\Rule
+{
+    /**
+     * @param list<non-empty-string> $monitoredAnnotations
+     */
+    public function __construct(
+        private readonly Type\FileTypeMapper $fileTypeMapper,
+        private readonly array $monitoredAnnotations,
+    ) {}
+
+    public function getNodeType(): string
+    {
+        return Node\Stmt::class;
+    }
+
+    public function processNode(Node $node, Analyser\Scope $scope): array
+    {
+        $errors = [];
+
+        foreach ($node->getComments() as $comment) {
+            $commentText = $comment->getText();
+
+            // Convert inline comments to phpdoc to allow usage of phpdoc parser
+            if (1 !== preg_match('#^/\*{2}#', $commentText)) {
+                $commentText = '/** '.preg_replace(['#^(/\*|//)#', '#\*/$#'], '', $commentText).' */';
+            }
+
+            // Parse and resolve phpdoc
+            $resolvedPhpDoc = $this->fileTypeMapper->getResolvedPhpDoc(
+                $scope->getFile(),
+                $scope->getClassReflection()?->getName(),
+                $scope->getTraitReflection()?->getName(),
+                $scope->getFunction()?->getName(),
+                $commentText,
+            );
+
+            foreach ($resolvedPhpDoc->getPhpDocNodes() as $phpDocNode) {
+                foreach ($phpDocNode->children as $phpDocChildNode) {
+                    // We only check phpdoc tag nodes
+                    if (!($phpDocChildNode instanceof PhpDocParser\Ast\PhpDoc\PhpDocTagNode)) {
+                        continue;
+                    }
+
+                    $name = ltrim($phpDocChildNode->name, '@');
+
+                    // Add error if ignore annotation has no error identifier configured
+                    if (in_array($name, $this->monitoredAnnotations) && '' === trim((string) $phpDocChildNode->value)) {
+                        $errors[] = $this->createRuleError($name, $scope, $node);
+                    }
+                }
+            }
+        }
+
+        return $errors;
+    }
+
+    /**
+     * @return Rules\IdentifierRuleError
+     */
+    private function createRuleError(string $annotation, Analyser\Scope $scope, Node $node): Rules\RuleError
+    {
+        $ruleError = Rules\RuleErrorBuilder::message(
+            sprintf('Using an @%s annotation without specifying an error identifier is not allowed.', $annotation),
+        );
+
+        return $ruleError
+            ->identifier('ignoreAnnotation.withoutErrorIdentifier')
+            ->tip('Read more at https://phpstan.org/user-guide/ignoring-errors and learn how to properly ignore errors.')
+            ->file($scope->getFile())
+            ->line($node->getStartLine())
+            ->nonIgnorable()
+            ->build()
+        ;
+    }
+}

--- a/tests/unit/Fixtures/Files/ignore-annotation-with-error-identifier.php
+++ b/tests/unit/Fixtures/Files/ignore-annotation-with-error-identifier.php
@@ -21,14 +21,13 @@ declare(strict_types=1);
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
-use EliasHaeussler\PHPStanConfig\Config;
+/**
+ * @param non-empty-string $name
+ */
+function hello(string $name): void
+{
+    echo sprintf('Hello, %s!', $name);
+}
 
-return Config\Config::create(__DIR__)
-    ->in('src', 'tests/unit')
-    ->not('tests/unit/Fixtures/Files')
-    ->with('extension.neon')
-    ->withBleedingEdge()
-    ->maxLevel()
-    ->useCacheDir('.build/cache/phpstan')
-    ->toArray()
-;
+// @ignore-next-line argument.type
+hello('');

--- a/tests/unit/Fixtures/Files/ignore-annotation-without-error-identifier.php
+++ b/tests/unit/Fixtures/Files/ignore-annotation-without-error-identifier.php
@@ -21,10 +21,13 @@ declare(strict_types=1);
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
-use ComposerUnused\ComposerUnused;
+/**
+ * @param non-empty-string $name
+ */
+function hello(string $name): void
+{
+    echo sprintf('Hello, %s!', $name);
+}
 
-return static function (ComposerUnused\Configuration\Configuration $config): ComposerUnused\Configuration\Configuration {
-    return $config
-        ->addPatternFilter(ComposerUnused\Configuration\PatternFilter::fromString('/phpstan\/.*/'))
-    ;
-};
+// @ignore-next-line
+hello('');

--- a/tests/unit/Fixtures/Files/no-ignore-annotations.php
+++ b/tests/unit/Fixtures/Files/no-ignore-annotations.php
@@ -21,14 +21,12 @@ declare(strict_types=1);
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
-use EliasHaeussler\PHPStanConfig\Config;
+/**
+ * @param non-empty-string $name
+ */
+function hello(string $name): void
+{
+    echo sprintf('Hello, %s!', $name);
+}
 
-return Config\Config::create(__DIR__)
-    ->in('src', 'tests/unit')
-    ->not('tests/unit/Fixtures/Files')
-    ->with('extension.neon')
-    ->withBleedingEdge()
-    ->maxLevel()
-    ->useCacheDir('.build/cache/phpstan')
-    ->toArray()
-;
+hello('');

--- a/tests/unit/Rule/IgnoreAnnotationWithoutErrorIdentifierRuleTest.php
+++ b/tests/unit/Rule/IgnoreAnnotationWithoutErrorIdentifierRuleTest.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/phpstan-config".
+ *
+ * Copyright (C) 2023-2025 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\PHPStanConfig\Tests\Rule;
+
+use EliasHaeussler\PHPStanConfig as Src;
+use PHPStan\Rules;
+use PHPStan\Testing;
+use PHPStan\Type;
+use PHPUnit\Framework;
+
+use function dirname;
+
+/**
+ * IgnoreAnnotationWithoutErrorIdentifierRuleTest.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ *
+ * @extends Testing\RuleTestCase<Src\Rule\IgnoreAnnotationWithoutErrorIdentifierRule>
+ */
+#[Framework\Attributes\CoversClass(Src\Rule\IgnoreAnnotationWithoutErrorIdentifierRule::class)]
+final class IgnoreAnnotationWithoutErrorIdentifierRuleTest extends Testing\RuleTestCase
+{
+    #[Framework\Attributes\Test]
+    public function processNodeReturnsNoErrorsIfNoMonitoredIgnoreAnnotationsAreUsed(): void
+    {
+        $this->analyse(
+            [
+                dirname(__DIR__).'/Fixtures/Files/no-ignore-annotations.php',
+            ],
+            [],
+        );
+    }
+
+    #[Framework\Attributes\Test]
+    public function processNodeReturnsNoErrorsIfMonitoredIgnoreAnnotationHasErrorIdentifierConfigured(): void
+    {
+        $this->analyse(
+            [
+                dirname(__DIR__).'/Fixtures/Files/ignore-annotation-with-error-identifier.php',
+            ],
+            [],
+        );
+    }
+
+    #[Framework\Attributes\Test]
+    public function processNodeReturnsErrorsIfMonitoredIgnoreAnnotationHasNoErrorIdentifierConfigured(): void
+    {
+        $this->analyse(
+            [
+                dirname(__DIR__).'/Fixtures/Files/ignore-annotation-without-error-identifier.php',
+            ],
+            [
+                [
+                    'Using an @ignore-next-line annotation without specifying an error identifier is not allowed.',
+                    33,
+                    'Read more at https://phpstan.org/user-guide/ignoring-errors and learn how to properly ignore errors.',
+                ],
+            ],
+        );
+    }
+
+    protected function getRule(): Rules\Rule
+    {
+        return new Src\Rule\IgnoreAnnotationWithoutErrorIdentifierRule(
+            self::getContainer()->getByType(Type\FileTypeMapper::class),
+            // Omitting the phpstan- prefix is intended, otherwise this would cause side effects in tests
+            [
+                'ignore-line',
+                'ignore-next-line',
+            ],
+        );
+    }
+}


### PR DESCRIPTION
This PR introduces a `ignoreAnnotationWithoutErrorIdentifier` rule. It is used to monitor `@phpstan-ignore-*` annotations without error identifiers.