### PR TITLE
[BUGFIX] Assure absolute path in resulting ignoreError configuration

### DIFF
--- a/src/Config/Config.php
+++ b/src/Config/Config.php
@@ -220,7 +220,7 @@ final class Config
         ];
 
         if (null !== $path) {
-            $error['path'] = $path;
+            $error['path'] = $this->expandPath($path);
         }
         if (null !== $count) {
             $error['count'] = $count;

--- a/tests/unit/Config/ConfigTest.php
+++ b/tests/unit/Config/ConfigTest.php
@@ -436,23 +436,29 @@ final class ConfigTest extends Framework\TestCase
             null,
             ['message' => '#^foo$#'],
         ];
-        yield 'message and path' => [
+        yield 'message and relative path' => [
             'baz',
             null,
             null,
-            ['message' => '#^foo$#', 'path' => 'baz'],
+            ['message' => '#^foo$#', 'path' => '/my-project/baz'],
+        ];
+        yield 'message and absolute path' => [
+            '/foo/baz',
+            null,
+            null,
+            ['message' => '#^foo$#', 'path' => '/foo/baz'],
         ];
         yield 'message, path and count' => [
             'baz',
             3,
             null,
-            ['message' => '#^foo$#', 'path' => 'baz', 'count' => 3],
+            ['message' => '#^foo$#', 'path' => '/my-project/baz', 'count' => 3],
         ];
         yield 'message, path, count and reportUnmatched' => [
             'baz',
             3,
             true,
-            ['message' => '#^foo$#', 'path' => 'baz', 'count' => 3, 'reportUnmatched' => true],
+            ['message' => '#^foo$#', 'path' => '/my-project/baz', 'count' => 3, 'reportUnmatched' => true],
         ];
     }
 }


### PR DESCRIPTION
The path in `ignoreError` configurations must be absolute for PHPStan to properly read from it.