### PR TITLE
[FEATURE] Add config option to enable or disable custom rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,9 @@ $config->formatAs(PHPStanConfig\Enums\ErrorFormat::Json);
 // Treat phpdoc types as certain
 $config->treatPhpDocTypesAsCertain();
 
+// Enable or disable custom rules (see rules below)
+$config->useCustomRule('ignoreAnnotationWithoutErrorIdentifier', false);
+
 // Include Doctrine set
 $doctrineSet = PHPStanConfig\Set\DoctrineSet::create()
     ->withObjectManagerLoader('tests/object-manager.php')

--- a/src/Config/Config.php
+++ b/src/Config/Config.php
@@ -294,6 +294,13 @@ final class Config
         return $this;
     }
 
+    public function useCustomRule(string $identifier, bool $enable = true): self
+    {
+        $this->parameters->set($identifier.'/enabled', $enable);
+
+        return $this;
+    }
+
     /**
      * @return array{
      *     includes: list<non-empty-string>,

--- a/tests/unit/Config/ConfigTest.php
+++ b/tests/unit/Config/ConfigTest.php
@@ -420,6 +420,23 @@ final class ConfigTest extends Framework\TestCase
         self::assertSame($expected, $this->subject->toArray());
     }
 
+    #[Framework\Attributes\Test]
+    public function useCustomRuleEnablesOrDisablesCustomRule(): void
+    {
+        $this->subject->useCustomRule('foo');
+
+        $expected = [
+            'includes' => [],
+            'parameters' => [
+                'foo' => [
+                    'enabled' => true,
+                ],
+            ],
+        ];
+
+        self::assertSame($expected, $this->subject->toArray());
+    }
+
     /**
      * @return Generator<string, array{
      *     non-empty-string|null,


### PR DESCRIPTION
This PR adds a new Config method `useCustomRule` which allows to enable or disable custom rules.