### PR TITLE
[BUGFIX] Don't override scope in rule error

### DIFF
--- a/src/Rule/IgnoreAnnotationWithoutErrorIdentifierRule.php
+++ b/src/Rule/IgnoreAnnotationWithoutErrorIdentifierRule.php
@@ -109,8 +109,6 @@ final class IgnoreAnnotationWithoutErrorIdentifierRule implements Rules\Rule
         return $ruleError
             ->identifier('ignoreAnnotation.withoutErrorIdentifier')
             ->tip('Read more at https://phpstan.org/user-guide/ignoring-errors and learn how to properly ignore errors.')
-            ->file($scope->getFile())
-            ->line($node->getStartLine())
             ->nonIgnorable()
             ->build()
         ;


### PR DESCRIPTION
Error scope is properly applied by PHPStan itself. Therefore, we shouldn't override it in custom rule errors.