### PR TITLE
[FEATURE] Add support for error identifier in `Config::ignoreError`

### DIFF
--- a/src/Exception/Exception.php
+++ b/src/Exception/Exception.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/phpstan-config".
+ *
+ * Copyright (C) 2023-2025 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\PHPStanConfig\Exception;
+
+/**
+ * Exception.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ */
+abstract class Exception extends \Exception {}

--- a/src/Exception/IgnoreErrorEntryIsNotValid.php
+++ b/src/Exception/IgnoreErrorEntryIsNotValid.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/phpstan-config".
+ *
+ * Copyright (C) 2023-2025 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\PHPStanConfig\Exception;
+
+/**
+ * IgnoreErrorEntryIsNotValid.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ */
+final class IgnoreErrorEntryIsNotValid extends Exception
+{
+    public function __construct()
+    {
+        parent::__construct(
+            'Either message or identifier must be given for an ignoreError entry to be valid.',
+            1745858010,
+        );
+    }
+}

--- a/tests/unit/Config/ConfigTest.php
+++ b/tests/unit/Config/ConfigTest.php
@@ -252,20 +252,40 @@ final class ConfigTest extends Framework\TestCase
         self::assertSame($expected, $this->subject->toArray());
     }
 
+    #[Framework\Attributes\Test]
+    public function ignoreErrorThrowsExceptionIfNeitherMessageNorIdentifierAreSet(): void
+    {
+        $this->expectExceptionObject(
+            new Src\Exception\IgnoreErrorEntryIsNotValid(),
+        );
+
+        $this->subject->ignoreError();
+    }
+
     /**
-     * @param non-empty-string|null                                                                         $path
-     * @param positive-int|null                                                                             $count
-     * @param array{message: string, path?: non-empty-string, count?: positive-int, reportUnmatched?: bool} $expected
+     * @param non-empty-string|null $message
+     * @param non-empty-string|null $path
+     * @param positive-int|null     $count
+     * @param non-empty-string|null $identifier
+     * @param array{
+     *     message?: non-empty-string,
+     *     path?: non-empty-string,
+     *     count?: positive-int,
+     *     reportUnmatched?: bool,
+     *     identifier?: non-empty-string,
+     * } $expected
      */
     #[Framework\Attributes\Test]
     #[Framework\Attributes\DataProvider('ignoreErrorConfiguresIgnoreErrorForGivenMessageDataProvider')]
     public function ignoreErrorConfiguresIgnoreErrorForGivenMessage(
+        ?string $message,
         ?string $path,
         ?int $count,
         ?bool $reportUnmatched,
+        ?string $identifier,
         array $expected,
     ): void {
-        $this->subject->ignoreError('foo', $path, $count, $reportUnmatched);
+        $this->subject->ignoreError($message, $path, $count, $reportUnmatched, $identifier);
 
         self::assertSame(
             [
@@ -440,42 +460,76 @@ final class ConfigTest extends Framework\TestCase
     /**
      * @return Generator<string, array{
      *     non-empty-string|null,
+     *     non-empty-string|null,
      *     positive-int|null,
      *     bool|null,
-     *     array{message: string, path?: non-empty-string, count?: positive-int, reportUnmatched?: bool},
+     *     non-empty-string|null,
+     *     array{
+     *         message?: string,
+     *         path?: non-empty-string,
+     *         count?: positive-int,
+     *         reportUnmatched?: bool,
+     *         identifier?: non-empty-string,
+     *     },
      * }>
      */
     public static function ignoreErrorConfiguresIgnoreErrorForGivenMessageDataProvider(): Generator
     {
         yield 'message only' => [
+            'foo',
+            null,
             null,
             null,
             null,
             ['message' => '#^foo$#'],
         ];
         yield 'message and relative path' => [
+            'foo',
             'baz',
+            null,
             null,
             null,
             ['message' => '#^foo$#', 'path' => '/my-project/baz'],
         ];
         yield 'message and absolute path' => [
+            'foo',
             '/foo/baz',
+            null,
             null,
             null,
             ['message' => '#^foo$#', 'path' => '/foo/baz'],
         ];
         yield 'message, path and count' => [
+            'foo',
             'baz',
             3,
+            null,
             null,
             ['message' => '#^foo$#', 'path' => '/my-project/baz', 'count' => 3],
         ];
         yield 'message, path, count and reportUnmatched' => [
+            'foo',
             'baz',
             3,
             true,
+            null,
             ['message' => '#^foo$#', 'path' => '/my-project/baz', 'count' => 3, 'reportUnmatched' => true],
+        ];
+        yield 'message, path, count, reportUnmatched and identifier' => [
+            'foo',
+            'baz',
+            3,
+            true,
+            'boo',
+            ['message' => '#^foo$#', 'path' => '/my-project/baz', 'count' => 3, 'reportUnmatched' => true, 'identifier' => 'boo'],
+        ];
+        yield 'identifier only' => [
+            null,
+            null,
+            null,
+            null,
+            'foo',
+            ['identifier' => 'foo'],
         ];
     }
 }

--- a/tests/unit/Exception/IgnoreErrorEntryIsNotValidTest.php
+++ b/tests/unit/Exception/IgnoreErrorEntryIsNotValidTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/phpstan-config".
+ *
+ * Copyright (C) 2023-2025 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\PHPStanConfig\Tests\Exception;
+
+use EliasHaeussler\PHPStanConfig as Src;
+use PHPUnit\Framework;
+
+/**
+ * IgnoreErrorEntryIsNotValidTest.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ */
+#[Framework\Attributes\CoversClass(Src\Exception\IgnoreErrorEntryIsNotValid::class)]
+final class IgnoreErrorEntryIsNotValidTest extends Framework\TestCase
+{
+    #[Framework\Attributes\Test]
+    public function constructorReturnsExceptionForInvalidIgnoreErrorEntry(): void
+    {
+        $actual = new Src\Exception\IgnoreErrorEntryIsNotValid();
+
+        self::assertSame(
+            'Either message or identifier must be given for an ignoreError entry to be valid.',
+            $actual->getMessage(),
+        );
+        self::assertSame(1745858010, $actual->getCode());
+    }
+}


### PR DESCRIPTION
This pull request introduces enhancements to the `ignoreError` method in the `Config` class, adds new exception handling, and updates related tests. The changes improve error validation and configuration flexibility by introducing an optional `identifier` parameter and ensuring stricter validation for invalid inputs.

### Updates to `ignoreError` method:
* Enhanced the `ignoreError` method in `src/Config/Config.php` to accept an optional `identifier` parameter for error entries. Added validation to ensure either `message` or `identifier` is provided, throwing a new `IgnoreErrorEntryIsNotValid` exception if neither is set. [[1]](diffhunk://#diff-18d9e9c6768a133f4fc7723d566dc36b5a1a07bee3c30396619c76cd85422bfeL201-R231) [[2]](diffhunk://#diff-18d9e9c6768a133f4fc7723d566dc36b5a1a07bee3c30396619c76cd85422bfeR241-R243)

### New exception classes:
* Introduced an abstract `Exception` class in `src/Exception/Exception.php` to serve as a base for custom exceptions.
* Added a specific `IgnoreErrorEntryIsNotValid` exception class to handle invalid `ignoreError` entries.

### Test suite enhancements:
* Updated `ConfigTest` to include test cases for the new `identifier` parameter and to validate that the `IgnoreErrorEntryIsNotValid` exception is thrown when neither `message` nor `identifier` is provided. [[1]](diffhunk://#diff-0a4b6e6c4034bad3f9016adaabd57168aba4a824af2778cd434a0815f2de0ba7R255-R288) [[2]](diffhunk://#diff-0a4b6e6c4034bad3f9016adaabd57168aba4a824af2778cd434a0815f2de0ba7R463-R533)
* Added a dedicated test class `IgnoreErrorEntryIsNotValidTest` to verify the behavior of the `IgnoreErrorEntryIsNotValid` exception.